### PR TITLE
[WIP] Add nvm and some node versions to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,16 @@ ENV LC_ALL en_US.UTF-8
 # Install general dependencies
 RUN apt-get update && apt-get install -y build-essential git curl libssl-dev libreadline-dev zlib1g-dev
 
-# get the latest version of node
-# https://nodejs.org/en/download/package-manager/
-RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash - \
-	&& apt-get install -y nodejs
+# install nvm and install versions 4 and 6
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_DEFAULT_VERSION 4
+RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
+  && . "$NVM_DIR/nvm.sh" \
+  && nvm install $NODE_DEFAULT_VERSION \
+  && nvm install 6 \
+  && nvm use $NODE_DEFAULT_VERSION
+ENV NODE_PATH $NVM_DIR/v$NODE_DEFAULT_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/versions/node/v$NODE_DEFAULT_VERSION/bin:$PATH
 
 # skip installing gem documentation
 RUN echo 'install: --no-document\nupdate: --no-document' >> "$HOME/.gemrc"
@@ -33,8 +39,8 @@ ENV PATH $GEM_HOME/bin:$PATH
 ENV BUNDLER_VERSION 1.13.5
 
 RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin"
+  && bundle config --global path "$GEM_HOME" \
+  && bundle config --global bin "$GEM_HOME/bin"
 
 # don't create ".bundle" in all our apps
 ENV BUNDLE_APP_CONFIG $GEM_HOME


### PR DESCRIPTION
**NOT READY FOR MERGE**

Install `nvm` into the container and use that to install versions 4 and 6 of node. These are just the default versions, since nvm is installed any user can install any version they need.

Not sure if we'd want a separate container or if we'd even want to change the name of this container even though it now supports node and ruby.

Required for 18F/federalist-docker-build#13
Refs 18F/federalist#478
