### PR TITLE
Move off buildpack-deps and use ruby-build to install ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A copy of https://github.com/docker-library/ruby/blob/master/2.2/Dockerfile that uses Ubuntu Trusty as the base image, includes a recent version of node.js, and sets the locale to `en_US.UTF-8`.
+A copy of https://github.com/docker-library/ruby/blob/master/2.2/Dockerfile that uses Ubuntu Trusty as the base image, installs ruby via ruby-build, includes a recent version of node.js, and sets the locale to `en_US.UTF-8`.
 
 ### Public domain
 


### PR DESCRIPTION
This commit makes some changes in response to some discovered when we used Clair to scan this image.

This commit uses `ubuntu:trusty` as the parent image instead of `buildpack-deps:trusty`.
The disadvantage of this is that we have to install some simple dependencies like `curl`, `libssl`, etc.
The advantage is we don't pick up a lot of tools that we don't use that have a lot of CVEs (example ImageMagick`).

This commit also uses `ruby-build` to install ruby instead of installing from the source.
Before this commit, Clair was able to find a significant number of vulnerabilities in the tools we used to compile ruby.
Using ruby-build enables us to avoid that problem by only including specifically what is needed to install ruby.
