### PR TITLE
Load NVM in .profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,8 @@ RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | b
   && . "$NVM_DIR/nvm.sh" \
   && nvm install $NODE_DEFAULT_VERSION \
   && nvm install 6 \
-  && nvm use $NODE_DEFAULT_VERSION
-ENV NODE_PATH $NVM_DIR/v$NODE_DEFAULT_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/versions/node/v$NODE_DEFAULT_VERSION/bin:$PATH
+  && nvm use $NODE_DEFAULT_VERSION \
+  && echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"' >> $HOME/.profile
 
 # skip installing gem documentation
 RUN echo 'install: --no-document\nupdate: --no-document' >> "$HOME/.gemrc"


### PR DESCRIPTION
This commit causes nvm to be loaded in .profile so that it will be loaded when bash starts in login mode.
By default this is done in `.bashrc` which is only loaded in interactive mode.
