### PR TITLE
Remove BUNDLE_APP_CONFIG env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,3 @@ ENV RUBY_VERSION 2.3.1
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c 'rvm install $RUBY_VERSION && rvm use --default $RUBY_VERSION'
 RUN echo rvm_silence_path_mismatch_check_flag=1 >> /etc/rvmrc
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME


### PR DESCRIPTION
Prior to 04b90fb1f2bcd915b3bc5c40af7624a23e63736a, the bundler app config was set to the the value of `GEM_HOME`. This caused problems `GEM_HOME` was unset in favor of letting rvm manage the `GEM_HOME` variable. The result was `BUNDLER_APP_CONFIG` being set to an empty string. As a result of this, bundler was looking for `./config` when trying to load it's configs. If an app had a `config` file or directory, it would cause any `bundle` commands to fail.